### PR TITLE
Feat/merge default settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Validate & Release
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+        registry-url: https://registry.npmjs.org/
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,4 @@ jobs:
     - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,13 @@
+name: Validate
+on: push
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run validate

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+**.test.**
+examples
+.github
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -69,8 +69,17 @@ ifconfig -u | grep 'inet ' | grep -v 127.0.0.1 | cut -d\  -f2 | head -1
 #### Add the following to your `.envrc` file:
 `export DATABASE_URL=postgres://postgres:examplepassword@<your-public-ip>:5432/postgres?sslmode=disable`
 
-#### Run the server
+Allow .envrc file
+```sh
+direnv allow .
 ```
+### Run the example migration
+```sh
+npx -p pg -p node-pg-migrate -c "node-pg-migrate up -m examples/migrations"
+```
+
+#### Run the server
+```sh
 npm run example -- -l info -w
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,52 @@ Takes inspiration from the following resources:
 - [Using Postgraphile as a library](https://www.graphile.org/postgraphile/usage-library)
 - [Postgraphile's Fastify v3 example](https://github.com/graphile/postgraphile/blob/v4/examples/servers/fastify3/rum-and-raisin.ts)
 
+## Usage
+
+```sh
+npm install @autotelic/fastify-postgraphile
+```
+
+```js
+const postGraphile = require('@autotelic/fastify-postgraphile')
+const { DATABASE_URL } = process.env
+
+module.exports = function (fastify, options, next) {
+    fastify.register(postGraphile, { database: DATABASE_URL })
+
+    fastify.get('/', (req, reply) => {
+      reply.type('application/json')
+      reply.send({ foo: 'bar' })
+    })
+
+    fastify.post('/', (req, reply) => {
+      reply.type('application/json')
+      reply.send({ hello: 'world' })
+    })
+
+    next()
+}
+```
+
+### PostGraphile Options
+
+| Option | Status | Type | Default | Description |
+| ------- | :---: | :---: | :---: | --- |
+| `database` | **Required** | String | - | A database connection string |
+| `schemas` | Optional | String | 'public' | Description |
+| `settings` | Optional | Object | - | An object containing PostGraphile settings to be combined with the default settings. **Defaults are not overwritten.** |
+| `overrides` | Optional | Object | - | An object containing PostGraphile settings that will **overwrite default settings.** |
+
+### Default Settings
+
+The default options applied by `fastify-postgraphile` are the [recommended PostGraphile options](Recommended-Options).
+
+These defaults can be added to or changed by passing additional PostGraphile Options in with either the `settings` object or the `overrides` object.
+
+Options in the `settings` object will be deeply merged with the default options but the defaults will not be changed. 
+
+Options in the `overrides` object will replace any corresponding default options. 
+
 ## Run the example
 
 #### Configure and run a local Postgres Container
@@ -35,3 +81,5 @@ http post localhost:3000
 #### Explore Graphiql
 
 [localhost:3000/graphiql](localhost:3000/graphiql)
+
+[Recommended-Options][https://www.graphile.org/postgraphile/usage-library/#recommended-options]

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ npm install @autotelic/fastify-postgraphile
 ```
 
 ```js
-const postGraphile = require('@autotelic/fastify-postgraphile')
+const fastifyPostGraphile = require('@autotelic/fastify-postgraphile')
 const { DATABASE_URL } = process.env
 
 module.exports = function (fastify, options, next) {
-    fastify.register(postGraphile, { database: DATABASE_URL })
+    fastify.register(fastifyPostGraphile, { database: DATABASE_URL })
 
     fastify.get('/', (req, reply) => {
       reply.type('application/json')
@@ -33,24 +33,21 @@ module.exports = function (fastify, options, next) {
 }
 ```
 
-### PostGraphile Options
+### API: fastifyPostGraphile(database, schemas, settings)
 
-| Option | Status | Type | Default | Description |
+| Name | Status | Type | Default | Description |
 | ------- | :---: | :---: | :---: | --- |
-| `database` | **Required** | String | - | A database connection string |
-| `schemas` | Optional | String | 'public' | Description |
-| `settings` | Optional | Object | - | An object containing PostGraphile settings to be combined with the default settings. **Defaults are not overwritten.** |
-| `overrides` | Optional | Object | - | An object containing PostGraphile settings that will **overwrite default settings.** |
+| `database` | **Required** | String/Object | - | An object or string that will be passed to the pg library and used to connect to a PostgreSQL backend, OR a pg.Pool to use. |
+| `schemas` | Optional | String/[String] | 'public' | A string, or array of strings, which specifies the PostgreSQL schema(s) to expose via PostGraphile; defaults to 'public' |
+| `settings` | Optional | Object | - | An object containing [PostGraphile options](options-reference) to be combined with the [default recommended options](Recommended-Options). Conflicts are overwritten |
 
-### Default Settings
+### Default Options
 
 The default options applied by `fastify-postgraphile` are the [recommended PostGraphile options](Recommended-Options).
 
-These defaults can be added to or changed by passing additional PostGraphile Options in with either the `settings` object or the `overrides` object.
+These defaults can be added to or changed by passing additional PostGraphile Options in with the `settings` object.
 
-Options in the `settings` object will be deeply merged with the default options but the defaults will not be changed. 
-
-Options in the `overrides` object will replace any corresponding default options. 
+Note: If you add additional plugins using the `appendPlugins` option and would like to still use the default [`simplifyInflector` plugin](pg-simplify-inflector) it will need to be added again as part of your `settings` object. 
 
 ## Run the example
 
@@ -83,3 +80,5 @@ http post localhost:3000
 [localhost:3000/graphiql](localhost:3000/graphiql)
 
 [Recommended-Options][https://www.graphile.org/postgraphile/usage-library/#recommended-options]
+[options-reference][https://www.graphile.org/postgraphile/usage-library/#api-postgraphilepgconfig-schemaname-options]
+[pg-simplify-inflector][https://www.npmjs.com/package/@graphile-contrib/pg-simplify-inflector]

--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ module.exports = function (fastify, options, next) {
 | ------- | :---: | :---: | :---: | --- |
 | `database` | **Required** | String/Object | - | An object or string that will be passed to the pg library and used to connect to a PostgreSQL backend, OR a pg.Pool to use. |
 | `schemas` | Optional | String/[String] | 'public' | A string, or array of strings, which specifies the PostgreSQL schema(s) to expose via PostGraphile; defaults to 'public' |
-| `settings` | Optional | Object | - | An object containing [PostGraphile options](options-reference) to be combined with the [default recommended options](Recommended-Options). Conflicts are overwritten |
+| `settings` | Optional | Object | - | An object containing [PostGraphile options](options-reference) to be combined with the [default recommended options](Recommended-Options). |
 
 ### Default Options
 
 The default options applied by `fastify-postgraphile` are the [recommended PostGraphile options](Recommended-Options).
 
-These defaults can be added to or changed by passing additional PostGraphile Options in with the `settings` object.
+These defaults can be added to or changed by passing additional PostGraphile Options in with the `settings` object. The `` and `` arrays will be concatenaded with any new options passed in.
 
-Note: If you add additional plugins using the `appendPlugins` option and would like to still use the default [`simplifyInflector` plugin](pg-simplify-inflector) it will need to be added again as part of your `settings` object. 
+Note: If you need to disable the default [`simplifyInflector` plugin](pg-simplify-inflector), pass the exported reference to it into the `skipPlugins` option array. 
+
+e.g.
+```js
+skipPlugins: [fastifyPostGraphile.DEFAULT_INFLECTOR]
+```
 
 ## Run the example
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module.exports = function (fastify, options, next) {
 
 The default options applied by `fastify-postgraphile` are the [recommended PostGraphile options](Recommended-Options).
 
-These defaults can be added to or changed by passing additional PostGraphile Options in with the `settings` object. The `` and `` arrays will be concatenaded with any new options passed in.
+These defaults can be added to or changed by passing additional PostGraphile Options in with the `settings` object. The `extendedErrors` and `appendPlugins` arrays will be concatenated with any new options passed in.
 
 Note: If you need to disable the default [`simplifyInflector` plugin](pg-simplify-inflector), pass the exported reference to it into the `skipPlugins` option array. 
 

--- a/example.js
+++ b/example.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const postGraphile = require('.')
+const fastifyPostGraphile = require('.')
 const { DATABASE_URL } = process.env
 
 module.exports = function (fastify, options, next) {
-    fastify.register(postGraphile, { database: DATABASE_URL })
+  fastify.register(fastifyPostGraphile, { database: DATABASE_URL })
 
-    fastify.get('/', (req, reply) => {
-      reply.type('application/json')
-      reply.send({ foo: 'bar' })
-    })
+  fastify.get('/', (req, reply) => {
+    reply.type('application/json')
+    reply.send({ foo: 'bar' })
+  })
 
-    fastify.post('/', (req, reply) => {
-      reply.type('application/json')
-      reply.send({ hello: 'world' })
-    })
+  fastify.post('/', (req, reply) => {
+    reply.type('application/json')
+    reply.send({ hello: 'world' })
+  })
 
-    next()
+  next()
 }

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fastifyPostGraphile = require('.')
+const fastifyPostGraphile = require('..')
 const { DATABASE_URL } = process.env
 
 module.exports = function (fastify, options, next) {

--- a/examples/migrations/1611271538676_example-migration.js
+++ b/examples/migrations/1611271538676_example-migration.js
@@ -1,0 +1,29 @@
+/* eslint-disable camelcase */
+
+exports.up = (pgm) => {
+  pgm.createTable('users', {
+    id: 'id',
+    name: { type: 'varchar(1000)', notNull: true },
+    createdAt: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('current_timestamp')
+    }
+  })
+  pgm.createTable('posts', {
+    id: 'id',
+    userId: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"',
+      onDelete: 'cascade'
+    },
+    body: { type: 'text', notNull: true },
+    createdAt: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('current_timestamp')
+    }
+  })
+  pgm.createIndex('posts', 'userId')
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const {
   PostGraphileResponseFastify3
 } = require('postgraphile')
 const simplifyInflector = require('@graphile-contrib/pg-simplify-inflector')
+const merge = require('lodash.merge')
 
 const DECORATOR = 'fastify-postgraphile'
 
@@ -33,10 +34,12 @@ async function postGraphilePlugin (fastify, opts) {
   const {
     database,
     schemas = 'public',
-    settings = defaultSettings
+    settings
   } = opts
 
-  const middleware = postgraphile(database, schemas, settings)
+  const deepMergedSettings = merge({}, defaultSettings, settings)
+
+  const middleware = postgraphile(database, schemas, deepMergedSettings)
 
   const convertHandler = (handler) => (
     request,

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const {
   PostGraphileResponseFastify3
 } = require('postgraphile')
 const simplifyInflector = require('@graphile-contrib/pg-simplify-inflector')
-const mergeWith = require('lodash.mergewith')
 
 const DECORATOR = 'fastify-postgraphile'
 
@@ -34,23 +33,15 @@ async function postGraphilePlugin (fastify, opts) {
   const {
     database,
     schemas = 'public',
-    settings = {},
-    overrides = {}
+    settings = {}
   } = opts
 
-  // Deeply merge together user settings and default settings.
-  // New settings will be added
-  // Array settings will be concatenated together
-  // Existing default settings will be retained
-  const deepMergedSettings = mergeWith({}, settings, defaultSettings, concatNestedArrays)
-
-  // Apply overrides settings to replace/change any default settings
-  const mergedSettingsWithOverrides = {
-    ...deepMergedSettings,
-    ...overrides
+  const combinedSettings = {
+    ...defaultSettings,
+    ...settings
   }
 
-  const middleware = postgraphile(database, schemas, mergedSettingsWithOverrides)
+  const middleware = postgraphile(database, schemas, combinedSettings)
 
   const convertHandler = (handler) => (
     request,
@@ -81,9 +72,3 @@ async function postGraphilePlugin (fastify, opts) {
 module.exports = fastifyPlugin(postGraphilePlugin, {
   name: DECORATOR
 })
-
-function concatNestedArrays (objValue, srcValue) {
-  if (Array.isArray(objValue)) {
-    return objValue.concat(srcValue)
-  }
-}

--- a/index.js
+++ b/index.js
@@ -69,14 +69,13 @@ async function postGraphilePlugin (fastify, opts) {
   }
 }
 
-module.exports = fastifyPlugin(postGraphilePlugin, {
-  name: DECORATOR
-})
-
-module.exports.DEFAULT_INFLECTOR = DEFAULT_INFLECTOR
-
 function concatNestedArrays (objValue, srcValue) {
   if (Array.isArray(objValue)) {
     return objValue.concat(srcValue)
   }
 }
+
+module.exports.DEFAULT_INFLECTOR = DEFAULT_INFLECTOR
+module.exports = fastifyPlugin(postGraphilePlugin, {
+  name: DECORATOR
+})

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const {
   PostGraphileResponseFastify3
 } = require('postgraphile')
 const simplifyInflector = require('@graphile-contrib/pg-simplify-inflector')
-const merge = require('lodash.merge')
+const mergeWith = require('lodash.mergeWith')
 
 const DECORATOR = 'fastify-postgraphile'
 
@@ -37,7 +37,7 @@ async function postGraphilePlugin (fastify, opts) {
     settings
   } = opts
 
-  const deepMergedSettings = merge({}, defaultSettings, settings)
+  const deepMergedSettings = mergeWith({}, defaultSettings, settings, concatNestedArrays)
 
   const middleware = postgraphile(database, schemas, deepMergedSettings)
 
@@ -70,3 +70,9 @@ async function postGraphilePlugin (fastify, opts) {
 module.exports = fastifyPlugin(postGraphilePlugin, {
   name: DECORATOR
 })
+
+function concatNestedArrays (objValue, srcValue) {
+  if (Array.isArray(objValue)) {
+    return objValue.concat(srcValue)
+  }
+}

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const {
   PostGraphileResponseFastify3
 } = require('postgraphile')
 const simplifyInflector = require('@graphile-contrib/pg-simplify-inflector')
-const mergeWith = require('lodash.mergeWith')
+const mergeWith = require('lodash.mergewith')
 
 const DECORATOR = 'fastify-postgraphile'
 
@@ -34,12 +34,23 @@ async function postGraphilePlugin (fastify, opts) {
   const {
     database,
     schemas = 'public',
-    settings
+    settings = {},
+    overrides = {}
   } = opts
 
-  const deepMergedSettings = mergeWith({}, defaultSettings, settings, concatNestedArrays)
+  // Deeply merge together user settings and default settings.
+  // New settings will be added
+  // Array settings will be concatenated together
+  // Existing default settings will be retained
+  const deepMergedSettings = mergeWith({}, settings, defaultSettings, concatNestedArrays)
 
-  const middleware = postgraphile(database, schemas, deepMergedSettings)
+  // Apply overrides settings to replace/change any default settings
+  const mergedSettingsWithOverrides = {
+    ...deepMergedSettings,
+    ...overrides
+  }
+
+  const middleware = postgraphile(database, schemas, mergedSettingsWithOverrides)
 
   const convertHandler = (handler) => (
     request,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3731,10 +3731,10 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "lodash.merge": {
+    "lodash.mergewith": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3731,11 +3731,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "fastify-postgraphile",
+  "name": "@autotelic/fastify-postgraphile",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -3730,6 +3730,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3731,6 +3731,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -807,6 +807,12 @@
         "readdirp": "~3.5.0"
       }
     },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -1003,6 +1009,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
       "dev": true
     },
     "concat-map": {
@@ -2376,6 +2388,15 @@
         "locate-path": "^3.0.0"
       }
     },
+    "find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^3.1.2"
+      }
+    },
     "findit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
@@ -2984,6 +3005,78 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
+    },
+    "husky": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^4.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -4312,6 +4405,12 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true
+    },
     "opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -5338,6 +5437,12 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
+    "semver-regex": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "dev": true
+    },
     "semver-store": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
@@ -5380,6 +5485,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "slice-ansi": {
@@ -7393,6 +7504,12 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -7634,6 +7751,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "test",
-    "example": "fastify start example.js",
+    "example": "fastify start examples/example.js",
     "lint": "standard",
     "fix": "npm run lint -- --fix",
     "validate": "npm run lint && npm run test"

--- a/package.json
+++ b/package.json
@@ -3,11 +3,8 @@
   "version": "0.0.0",
   "description": "PostGraphile plugin for fastify",
   "main": "index.js",
-  "directories": {
-    "test": "test"
-  },
   "scripts": {
-    "test": "test",
+    "test": "tap -R classic -j1",
     "example": "fastify start examples/example.js",
     "lint": "standard",
     "fix": "npm run lint -- --fix",
@@ -39,15 +36,24 @@
     "postgraphile": "^4.10.0-alpha.0"
   },
   "devDependencies": {
-    "tap": "^14.0.0",
     "fastify": "^3.0.0",
     "fastify-cli": "^2.5.1",
+    "husky": "^4.3.8",
+    "lint-staged": "^10.2.11",
     "standard": "^14.3.4",
-    "lint-staged": "^10.2.11"
+    "tap": "^14.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
     "*.{js,jsx}": [
       "npm run fix"
     ]
+  },
+  "engines": {
+    "node": ">= 12.18.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "fastify-plugin": "^3.0.0",
+    "lodash.mergewith": "^4.6.2",
     "postgraphile": "^4.10.0-alpha.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "fastify-plugin": "^3.0.0",
+    "lodash.merge": "^4.6.2",
     "postgraphile": "^4.10.0-alpha.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "fastify-plugin": "^3.0.0",
-    "lodash.mergewith": "^4.6.2",
     "postgraphile": "^4.10.0-alpha.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "fastify-plugin": "^3.0.0",
-    "lodash.merge": "^4.6.2",
+    "lodash.mergewith": "^4.6.2",
     "postgraphile": "^4.10.0-alpha.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Summary
- added `lodash.mergewith` to incorporate user settings passed in with the defined default settings. 
- exported the default `simplifyInflector` plugin in case a future user wants to disable it using the `skipPlugins` option. 
- Updated examples with an example migration
- Updated readme for new functionality and documented API
- Added release and validate workflows

### Test Plan
- clone and install
- Run the example according to the readme
- Verify the example runs with all defaults - go to http://localhost:3000/graphiql 
- Modify example to include the settings object with `graphiql: false` 
e.g.
```js
  fastify.register(fastifyPostGraphile, { database: DATABASE_URL, settings: { graphiql: false } })
```
- Run the example and verify the graphiql interface is no longer active
- Modify example to include the settings object with `skipPlugins: [fastifyPostGraphile.DEFAULT_INFLECTOR]` 
- e.g.
```js
  fastify.register(fastifyPostGraphile, { database: DATABASE_URL, settings: { skipPlugins: [fastifyPostGraphile.DEFAULT_INFLECTOR] } })
```
- Run the example and verify that the entity names now start with "all". e.g. `allPosts` instead of `posts`